### PR TITLE
add monologue command

### DIFF
--- a/doomer/discord_utils.py
+++ b/doomer/discord_utils.py
@@ -54,6 +54,8 @@ def format_messages(messages, emoji_names=True, emphasize_names=True):
     return "\n".join(
         map(
             lambda msg: pre
+            + msg.created_at.strftime("%I:%M:%S %p")
+            + " "
             + get_nick(msg.author)
             + post
             + ": "


### PR DESCRIPTION
This allows doomer to ingest the last `n` messages to produce `m` tokens, free of any messaging metadata.  Sometimes doomer says cool shit and we want him to say more, but `>respond` is loaded with too much junk.